### PR TITLE
Allow configuration of log-level

### DIFF
--- a/charts/vault-autounseal/templates/configmap.yaml
+++ b/charts/vault-autounseal/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
   NAMESPACE: {{ .Release.Namespace }}
   VAULT_ROOT_TOKEN_SECRET: {{ .Values.settings.vault_root_token_secret }}
   VAULT_KEYS_SECRET: {{ .Values.settings.vault_keys_secret }}
+  LOGURU_LEVEL: {{ .Values.settings.log_level | default "INFO" }}


### PR DESCRIPTION
As the default log-level is set to INFO, unseal keys are logged to stdout by default and end up in container output and potential logging frameworks. Being able to set the log-level to WARNING solves this.