### PR TITLE
fixed helm install/upgrade error

### DIFF
--- a/charts/vault-autounseal/templates/configmap.yaml
+++ b/charts/vault-autounseal/templates/configmap.yaml
@@ -12,4 +12,4 @@ data:
   VAULT_ROOT_TOKEN_SECRET: {{ .Values.settings.vault_root_token_secret }}
   VAULT_KEYS_SECRET: {{ .Values.settings.vault_keys_secret }}
   LOGURU_LEVEL: {{ .Values.settings.log_level | default "INFO" }}
-  VAULT_SCAN_DELAY: {{ .Values.settings.scan_delay }}
+  VAULT_SCAN_DELAY: {{ .Values.settings.scan_delay | quote }}


### PR DESCRIPTION
fixed helm install/upgrade error:
'failed to create resource: ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string'