### PR TITLE
[40]: Wait for vault pods to have ip addresses before unsealing them

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,6 +239,7 @@ def get_vault_pods():
 
     tries = 0
     while tries < pod_retrieval_max_retries:
+        tries = tries + 1
         pod_list = api_instance.list_namespaced_pod(
             namespace=vault_namespace, label_selector=vault_label_selector
         )

--- a/app.py
+++ b/app.py
@@ -257,7 +257,7 @@ def get_vault_pods():
 
         return pod_list
 
-    logger.error("Waiting for Vault pods to be ready timed out.")
+    logger.error("Waiting for Vault pods to be ready timed out. Will exit.")
     exit(2)
 
 


### PR DESCRIPTION
If the vault auto-unsealed starts as fast as the vault pods, there is a risk that the vault pod does not yet have an IP address assigned. This changes are adding a wait, in case the IP address is not present in the vault pod.