### PR TITLE
Added ability to customize VAULT_LABEL_SELECTOR env var

### DIFF
--- a/charts/vault-autounseal/templates/configmap.yaml
+++ b/charts/vault-autounseal/templates/configmap.yaml
@@ -13,3 +13,4 @@ data:
   VAULT_KEYS_SECRET: {{ .Values.settings.vault_keys_secret }}
   LOGURU_LEVEL: {{ .Values.settings.log_level | default "INFO" }}
   VAULT_SCAN_DELAY: {{ .Values.settings.scan_delay | quote }}
+  VAULT_LABEL_SELECTOR: {{ .Values.settings.vault_label_selector }}

--- a/charts/vault-autounseal/templates/deployment.yaml
+++ b/charts/vault-autounseal/templates/deployment.yaml
@@ -11,10 +11,11 @@ spec:
       {{- include "vault-autounseal.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "vault-autounseal.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/vault-autounseal/values.yaml
+++ b/charts/vault-autounseal/values.yaml
@@ -66,3 +66,5 @@ settings:
   vault_keys_secret: vault-keys
   # time between polling for vault status, in seconds
   scan_delay: 5
+  # vault label to use to retrieve vault instance
+  vault_label_selector: vault-sealed=true


### PR DESCRIPTION
Setting a custom vault_label_selector is not possible right now as the value is not exported in the chart.
This PR provides the ability to do just that.