### PR TITLE
fix: default label selector for vault instance

### DIFF
--- a/charts/vault-autounseal/Chart.yaml
+++ b/charts/vault-autounseal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/vault-autounseal/values.yaml
+++ b/charts/vault-autounseal/values.yaml
@@ -67,4 +67,4 @@ settings:
   # time between polling for vault status, in seconds
   scan_delay: 5
   # vault label to use to retrieve vault instance
-  vault_label_selector: vault-sealed=true
+  vault_label_selector: app.kubernetes.io/instance=vault,component=server


### PR DESCRIPTION
This should fully resolve and release helm chart change: https://github.com/pyToshka/vault-autounseal/issues/39 